### PR TITLE
Don't hold analysis launches that don't have a valid proxy anymore

### DIFF
--- a/webservice/SubmissionsPOMS.py
+++ b/webservice/SubmissionsPOMS.py
@@ -1695,7 +1695,8 @@ class SubmissionsPOMS:
         #             or ("jobsub_client" in launch_script and "jobsub_client v_lite" not in launch_script))
 
         
-        proxyheld = role == "analysis" and not self.has_valid_proxy(proxyfile)# and not do_tokens
+        # proxyheld = role == "analysis" and not self.has_valid_proxy(proxyfile)# and not do_tokens
+        proxyheld = False
         if allheld or csheld or proxyheld:
 
             errnum = 423


### PR DESCRIPTION
This *used* to be a feature, but with proxies going away, we really shouldn't hold analysis launches due to lack of
current proxy.   We should maybe teach it to check the uploaded vault tokens instead (maybe just by date?) but
until we do that, this just doesn't call the check anymore.