### PR TITLE
change to make clone->editor save work

### DIFF
--- a/webservice/CampaignsPOMS.py
+++ b/webservice/CampaignsPOMS.py
@@ -1897,8 +1897,10 @@ class CampaignsPOMS:
             creator_id = new_campaign.creator
             #creator_role = ctx.get_vo_role(creator_id)
             creator_role = role
-            if creator_role.lower() in "production-shifter":
+
+            if creator_role.lower() in ("production-shifter", "superuser"):
                 creator_role = campaign_to_clone.creator_role
+
             new_campaign.creator_role = creator_role
             vo_role = creator_role.capitalize()
             
@@ -1966,17 +1968,10 @@ class CampaignsPOMS:
         except IntegrityError as e:
             ctx.db.rollback()
             logit.log("clone_campaign IntegrityError: ".join(e.args))
+            errorstr = str(e).split("\n")[0]
         
         logit.log("clone_campaign: Error: 500") 
-        raise cherrypy.HTTPError(500, "An error occurred while cloning this campaign.")
-            
-        
-        
-        
-        
-        
-        
-        
+        raise cherrypy.HTTPError(500, "An error '%s' occurred while cloning this campaign." % errorstr)
 
     def get_ui_editor_items(self, **kwargs):
         ctx = kwargs["ctx"]

--- a/webservice/templates/show_campaigns.html
+++ b/webservice/templates/show_campaigns.html
@@ -645,7 +645,7 @@ submitBtn.addEventListener("click", (e) => {
     var to = $("#to").val();
     var campaign_id = $("#campaign_id").val();
     var from = $("#from").val();
-    var url = "{{pomspath}}/gui_wf_clone/{{session_experiment}}/{{session_role}}?from=" + from + "&to=" + to + "&campaign_id=" + campaign_id;
+    var url = "{{pomspath}}/gui_wf_clone/{{session_experiment}}/{{session_role}}?from=" + from + "&to=" + to + "&campaign_id=" + campaign_id + "&campaign=" + to;
     window.location.href = url;
 });
 


### PR DESCRIPTION
Pass in "campaign" parameter of new campaign name to gui_wf_clone, so when it gets to the javascript gui editor code, it finds it in the current URL. 
Also a fix for cloning with 'superuser' role, and more informative error if you have a database consistency error.