### PR TITLE
Don't assume all projects are in mu2e_dd_prod... 

### DIFF
--- a/webservice/templates/submission_details.html
+++ b/webservice/templates/submission_details.html
@@ -139,7 +139,7 @@ Landscape (disabled, no info found) <br>
 {%if submission.project and data_handling_service == "sam" %}
 View the <a href="{{sam_base}}/station_monitor/{{session_experiment}}/stations/{{session_experiment}}/projects/{{submission.project}}">SAM Project</a> <br>
 {%elif submission.data_dispatcher_submission_obj and data_handling_service == "data_dispatcher" %}
-View the <a href="https://metacat.fnal.gov:9443/mu2e_dd_prod/gui/P/project?project_id={{submission.data_dispatcher_submission_obj.project_id}}">DataDispatcher Project</a> <br>
+View the <a href="https://metacat.fnal.gov:9443/{{session_experiment}}_dd{%if session_experiment != 'hypot'%} prod{%endif%}/gui/P/project?project_id={{submission.data_dispatcher_submission_obj.project_id}}">DataDispatcher Project</a> <br>
 {%endif%}
 
 {%if submission.jobsub_job_id %}

--- a/webservice/templates/submission_details.html
+++ b/webservice/templates/submission_details.html
@@ -139,7 +139,7 @@ Landscape (disabled, no info found) <br>
 {%if submission.project and data_handling_service == "sam" %}
 View the <a href="{{sam_base}}/station_monitor/{{session_experiment}}/stations/{{session_experiment}}/projects/{{submission.project}}">SAM Project</a> <br>
 {%elif submission.data_dispatcher_submission_obj and data_handling_service == "data_dispatcher" %}
-View the <a href="https://metacat.fnal.gov:9443/{{session_experiment}}_dd{%if session_experiment != 'hypot'%} prod{%endif%}/gui/P/project?project_id={{submission.data_dispatcher_submission_obj.project_id}}">DataDispatcher Project</a> <br>
+View the <a href="https://metacat.fnal.gov:9443/{{session_experiment}}_dd{%if session_experiment != 'hypot'%}_prod{%endif%}/gui/P/project?project_id={{submission.data_dispatcher_submission_obj.project_id}}">DataDispatcher Project</a> <br>
 {%endif%}
 
 {%if submission.jobsub_job_id %}


### PR DESCRIPTION
Current code the link to the data dispatcher project had "mu2e" hardcoded... now it should work for "hypot" and others.