### PR TITLE
Implement issue #81 file stats on campaign_overview

### DIFF
--- a/webservice/CampaignsPOMS.py
+++ b/webservice/CampaignsPOMS.py
@@ -386,7 +386,7 @@ class CampaignsPOMS:
         
         total = 0.0
         for ds in dslist:
-            count = ctx.sam.count_files(exp.experiment, "defname:%s" % ds)
+            count = ctx.sam.count_files(exp, "defname:%s" % ds)
             if count > 0:
                 total += count
         if total == 0:

--- a/webservice/DMRService.py
+++ b/webservice/DMRService.py
@@ -409,6 +409,7 @@ class DMRService:
                 child_close = ")" * int(depths.get(project_items[item["project_id"].campaign_stage_id],1))
                 queries[item["project_id"]] = f"{child_open}{fids}{child_close}"
             
+        logit.log(f"DMR-Service  | get_file_output_queries_for |  End | session: {cherrypy.session['Shrek']['session']}")
         return queries
     
     def list_filtered_projects(self, **kwargs):

--- a/webservice/SubmissionsPOMS.py
+++ b/webservice/SubmissionsPOMS.py
@@ -258,6 +258,30 @@ class SubmissionsPOMS:
         logit.log("got file pattern list: %s" % repr(plist))
         return plist
 
+    # update file counts for dd submissions:
+    def update_dd_file_counts(self, ctx,  submission_id):
+        logit.log(logit.DEBUG, f"update_file_counts: submission {submission_id}")
+        submission = ctx.db.query(Submission).options(joinedload(Submission.campaign_stage_obj)).filter(Submission.submission_id == submission_id).first()
+
+        if not submission.data_dispatcher_submission_obj:
+             logit.log(logit.DEBUG, f"update_file_counts: not a data_dispatcher submission")
+             return
+        if not hasattr(ctx, 'dmr_service'):
+            ctx.dmr_service = shrek.DMRService()
+
+        ctx.experiment = submission.campaign_stage_obj.experiment
+        ctx.dmr_service.initialize_session(ctx)
+
+        dd_task = submission.data_dispatcher_submission_obj
+
+        project_handles = ctx.dmr_service.get_project_handles(project_id=dd_task.project_id).get("project_handles", [])
+        attempted = [ph for ph in project_handles if ph["state"] != "initial" ]
+        done = [ph for ph in project_handles if ph["state"] == "done" ]
+        submission.files_consumed = len(attempted)
+        submission.files_generated = len(done)
+        ctx.db.add(submission)
+        ctx.db.flush()
+
     # utility for strong_dd completion type
     def all_dd_handles_not_reserved(self, ctx,  submission_id):
         # make sure we have the DMRService initialized
@@ -274,6 +298,8 @@ class SubmissionsPOMS:
         # need DMR session stutff for this submissions's experiment..
         ctx.experiment = submission.campaign_stage_obj.experiment
         ctx.dmr_service.initialize_session(ctx)
+
+
 
         # do two passes, first check if the reserved handles have
         # timed out, if not, bail.
@@ -400,6 +426,9 @@ class SubmissionsPOMS:
         projects_submissions = {}
         
         for submission_id, submission_details in all_subs.items():
+            
+            self.update_dd_file_counts(ctx, submission_id)
+
             if submission_details["completion_type"] == "complete":
                 completed.add(submission_id)
                 append_submission(submission_id, submission_details) # completed

--- a/webservice/templates/submission_details.html
+++ b/webservice/templates/submission_details.html
@@ -137,7 +137,7 @@ Landscape (disabled, no info found) <br>
 {%endif%}
 
 {%if submission.project and data_handling_service == "sam" %}
-View the <a href="{{sam_base}}/station_monitor/{{session_experiment}}/stations/{{session_experiment}}/projects/{{submission.project}}">SAM Project</a> <br>
+View the <a href="{{sam_base|replace('web',session_experiment)}}/station_monitor/{{session_experiment}}/stations/{{session_experiment}}/projects/{{submission.project}}">SAM Project</a> <br>
 {%elif submission.data_dispatcher_submission_obj and data_handling_service == "data_dispatcher" %}
 View the <a href="https://metacat.fnal.gov:9443/{{session_experiment}}_dd{%if session_experiment != 'hypot'%}_prod{%endif%}/gui/P/project?project_id={{submission.data_dispatcher_submission_obj.project_id}}">DataDispatcher Project</a> <br>
 


### PR DESCRIPTION
 
This adds a step to wrapup_tasks that updates file counts from data_dispatcher into the Submission object, so that they 
can be used in the campaign_overview page.