### PR TITLE
Reduce early completion

### DIFF
--- a/submission_broker/submission_agent.py
+++ b/submission_broker/submission_agent.py
@@ -330,7 +330,7 @@ class Agent:
         # also, if there really is just one job in the submission, the
         # "done" flag will be true, so it won't matter.
         #
-        if ntot > 1:
+        if ntot > 2:
             report_pct_complete = ncomp * 100.0 / ntot
         else:
             report_pct_complete = None
@@ -753,7 +753,7 @@ class Agent:
 
             ncomp = int(entry["completed"]) + int(entry["failed"]) + int(entry["cancelled"])
 
-            if ntot > 0:
+            if ntot > 2:
                 dd_pct = ncomp * 100.0 / ntot
             else:
                 dd_pct = 0

--- a/submission_broker/submission_agent.py
+++ b/submission_broker/submission_agent.py
@@ -744,14 +744,14 @@ class Agent:
         if type(dd_pct) == str:
             ntot = (int(entry["running"]) + int(entry["idle"]) + 
                 int(entry["held"]) + int(entry["completed"]) + 
-                int(entry["failed"]) + int(entry["cancelled"]))
+                int(entry["cancelled"]))
 
             if ntot >= self.known["maxjobs"].get(entry["pomsTaskID"], 0):
                 self.known["maxjobs"][entry["pomsTaskID"]] = ntot
             else:
                 ntot = self.known["maxjobs"][entry["pomsTaskID"]]
 
-            ncomp = int(entry["completed"]) + int(entry["failed"]) + int(entry["cancelled"])
+            ncomp = int(entry["completed"]) + int(entry["cancelled"])
 
             if ntot > 2:
                 dd_pct = ncomp * 100.0 / ntot

--- a/webservice/SubmissionsPOMS.py
+++ b/webservice/SubmissionsPOMS.py
@@ -1302,7 +1302,7 @@ class SubmissionsPOMS:
                     
                     # Submission updates
                     logit.log("DEBUG", "submission status: sub=%s, status=%s" % (submission.submission_id, status))
-                    if data_entry and status == "Running" and data_entry.get("pct_complete", None) and float(data_entry.get("pct_complete", 0)) >= submission.campaign_stage_snapshot_obj.completion_pct:
+                    if data_entry and status == "Running" and data_entry.get("pct_complete", None) and float(data_entry.get("pct_complete", 0)) >= submission.campaign_stage_snapshot_obj.completion_pct and submission.campaign_stage_snapshot_obj.completion_pct < 100 :
                         status = "Completed"
                     if status is not None:
                         submission_statuses_to_update[submission.submission_id] = status


### PR DESCRIPTION
So two checks updated here;

1. More avoiding completion percentage calculations on only 1 or 2 jobs, this can make us think submissions are completed when the leader job in a SAM dataset dag is completed.
2. Fix percent calculations which were double-counting "failed" jobs; the "failed" count is already included in the "completed" count, so don't add the failed to the completed jobs.